### PR TITLE
quickstart-nodejs to 0.0.4

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.1
 - name: quickstart-nodejs
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.4
 - name: scooters
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.12


### PR DESCRIPTION
Promote quickstart-nodejs to version 0.0.4